### PR TITLE
データサイズによって単位を変えるように修正

### DIFF
--- a/dev/frontend/src/components/ManagementFile/FileList.tsx
+++ b/dev/frontend/src/components/ManagementFile/FileList.tsx
@@ -57,6 +57,17 @@ const FileList: React.FC<FileListProps> = ({ csvList, loadingCsvList, fetchCsvLi
         });
     };
 
+    const formatDataSize = (size: number): string => {
+        const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+        for (let i = 0; i < units.length; i++) {
+            if (size < 1024 || i === units.length - 1) {
+                return `${size.toFixed(1)} ${units[i]}`;
+            }
+            size /= 1024;
+        }
+        return `${size.toFixed(1)} B`;
+    };
+
     return (
         <Card sx={{ p: 1, m: 5, borderRadius: '25px' }}>
             <CardContent>
@@ -71,7 +82,7 @@ const FileList: React.FC<FileListProps> = ({ csvList, loadingCsvList, fetchCsvLi
                             <TableHead>
                                 <TableRow>
                                     <TableCell align="center" sx={{ fontWeight: 'bold', fontSize: '18px' }}>ファイル名</TableCell>
-                                    <TableCell align="center" sx={{ fontWeight: 'bold', fontSize: '18px' }}>データサイズ （ KB ）</TableCell>
+                                    <TableCell align="center" sx={{ fontWeight: 'bold', fontSize: '18px' }}>データサイズ</TableCell>
                                     <TableCell align="center" sx={{ fontWeight: 'bold', fontSize: '18px' }}>列数</TableCell>
                                     <TableCell align="center" sx={{ fontWeight: 'bold', fontSize: '18px' }}>行数</TableCell>
                                     <TableCell align="center" sx={{ fontWeight: 'bold', fontSize: '18px' }}>最終更新日</TableCell>
@@ -91,7 +102,7 @@ const FileList: React.FC<FileListProps> = ({ csvList, loadingCsvList, fetchCsvLi
                                                     {csv.file_name.replace(/\.csv$/, '')}
                                                 </Button>
                                             </TableCell>
-                                            <TableCell align="center" sx={{ fontSize: '18px' }}>{csv.data_size}</TableCell>
+                                            <TableCell align="center" sx={{ fontSize: '18px' }}>{formatDataSize(csv.data_size)}</TableCell>
                                             <TableCell align="center" sx={{ fontSize: '18px' }}>{csv.data_columns}</TableCell>
                                             <TableCell align="center" sx={{ fontSize: '18px' }}>{csv.data_rows}</TableCell>
                                             <TableCell align="center" sx={{ fontSize: '18px' }}>{new Date(csv.last_accessed_date).toLocaleString()}</TableCell>


### PR DESCRIPTION
#50 
B、KB、MB、GB、TBの表記に対応

表示例
![image](https://github.com/user-attachments/assets/2eb6dc2a-6abf-411d-93ee-a6fcb56fb640)
